### PR TITLE
Add Command to Build Static Storybook

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,6 @@ php artisan blast:publish
 ### Options
 
 -   `--o, --output-dir` - the directory where to store built files relative to your `public` directory
--   `--s, --static-dir` - the directory where to load static files from, comma-separated list relative to your project root directory
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -317,6 +317,19 @@ Note: Defining custom statuses will override the existing statuses.
 
 Adding a `README.md` to your storybook blade directory will allow you to add notes to the Docs tab for each component in Storybook. The content of the markdown file will be output above the auto-generated Storybook content.
 
+## Publish Static Storybook
+
+Blast can build a static Storybook app and publish it to your public folder. You do this by running:
+
+```bash
+php artisan blast:publish
+```
+
+### Options
+
+-   `--o, --output-dir` - the directory where to store built files relative to your `public` directory
+-   `--s, --static-dir` - the directory where to load static files from, comma-separated list relative to your project root directory
+
 ## Troubleshooting
 
 If you see a `Failed to fetch` message when viewing your stories you will need to go to the path that Storybook is trying to load (open dev tools > network and right click the failed path and open in a new tab) and debug there. Any php errors or `dd` will trigger the `Failed to fetch` message.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ php artisan blast:generate-stories
 
 Global configuration can be done through the `config/blast.php`.
 
+Blast uses the `public_path()` to reference any static assets. This means that any assets in that directory will be available during developement as well as static builds published to the public directory using the `blast:publish` task.
+
 ### Options
 
 #### `storybook_server_url`

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "prod": "npm run production",
         "production": "mix --production",
         "build-storybook": "build-storybook",
-        "storybook": "concurrently \"start-storybook --quiet -p 6006\" \"npm run watch-components\" \"npm run watch-data\"",
+        "storybook": "concurrently \"start-storybook --quiet -s $STORYBOOK_STATIC_PATH -p 6006\" \"npm run watch-components\" \"npm run watch-data\"",
         "watch-components": "chokidar \"$COMPONENTPATH/**/*.blade.php\" -d 0 -c \"cd $PROJECTPATH && php artisan blast:generate-stories --watchEvent={event} -- '{path}';\"",
         "watch-data": "chokidar \"$COMPONENTPATH/data/**/*.php\" \"$COMPONENTPATH/**/*.md\" -d 0 -c \"cd $PROJECTPATH && php artisan blast:generate-stories;\"",
         "prepare": "husky install",

--- a/src/BlastServiceProvider.php
+++ b/src/BlastServiceProvider.php
@@ -5,6 +5,7 @@ namespace A17\Blast;
 use A17\Blast\Commands\Demo;
 use A17\Blast\Commands\GenerateStories;
 use A17\Blast\Commands\Launch;
+use A17\Blast\Commands\Publish;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
@@ -33,6 +34,7 @@ final class BlastServiceProvider extends ServiceProvider
                 Demo::class,
                 GenerateStories::class,
                 Launch::class,
+                Publish::class,
             ]);
         }
     }

--- a/src/Commands/GenerateStories.php
+++ b/src/Commands/GenerateStories.php
@@ -4,13 +4,15 @@ namespace A17\Blast\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Symfony\Component\Process\Process;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use A17\Blast\DataStore;
+use A17\Blast\Traits\Helpers;
 
 class GenerateStories extends Command
 {
+    use Helpers;
+
     /**
      * The name and signature of the console command.
      *
@@ -391,29 +393,5 @@ class GenerateStories extends Command
         }
 
         return false;
-    }
-
-    /**
-     * @return void
-     */
-    private function runProcessInBlast(
-        array $command,
-        $disableTimeout = false,
-        $envVars = null,
-    ) {
-        $process = new Process(
-            $command,
-            base_path($this->vendorPath),
-            $envVars,
-        );
-        $process->setTty(Process::isTtySupported());
-
-        if ($disableTimeout) {
-            $process->setTimeout(null);
-        } else {
-            $process->setTimeout(config('blast.build_timeout', 300));
-        }
-
-        $process->mustRun();
     }
 }

--- a/src/Commands/Launch.php
+++ b/src/Commands/Launch.php
@@ -4,10 +4,12 @@ namespace A17\Blast\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Symfony\Component\Process\Process;
+use A17\Blast\Traits\Helpers;
 
 class Launch extends Command
 {
+    use Helpers;
+
     /**
      * The name and signature of the console command.
      *
@@ -128,29 +130,5 @@ class Launch extends Command
             'PROJECTPATH' => base_path(),
             'COMPONENTPATH' => base_path('resources/views/stories'),
         ]);
-    }
-
-    /**
-     * @return void
-     */
-    private function runProcessInBlast(
-        array $command,
-        $disableTimeout = false,
-        $envVars = null,
-    ) {
-        $process = new Process(
-            $command,
-            base_path($this->vendorPath),
-            $envVars,
-        );
-        $process->setTty(Process::isTtySupported());
-
-        if ($disableTimeout) {
-            $process->setTimeout(null);
-        } else {
-            $process->setTimeout(config('blast.build_timeout', 300));
-        }
-
-        $process->mustRun();
     }
 }

--- a/src/Commands/Launch.php
+++ b/src/Commands/Launch.php
@@ -124,6 +124,7 @@ class Launch extends Command
 
         $this->runProcessInBlast(['npm', 'run', 'storybook'], true, [
             'STORYBOOK_SERVER_URL' => $this->storybookServer,
+            'STORYBOOK_STATIC_PATH' => public_path(),
             'STORYBOOK_STATUSES' => json_encode($this->storybookStatuses),
             'STORYBOOK_THEME' => json_encode($this->storybookTheme),
             'LIBSTORYPATH' => base_path($this->vendorPath . '/stories'),

--- a/src/Commands/Publish.php
+++ b/src/Commands/Publish.php
@@ -18,8 +18,7 @@ class Publish extends Command
      * @var string
      */
     protected $signature = 'blast:publish
-                                {--o|output-dir=storybook-static : Directory where to store built files}
-                                {--s|static-dir= : Directory where to load static files from relative to project root, comma-separated list}';
+                                {--o|output-dir=storybook-static : Directory where to store built files}';
 
     /**
      * The console command description.
@@ -55,7 +54,6 @@ class Publish extends Command
     public function handle()
     {
         $outputDir = $this->option('output-dir');
-        $staticDir = $this->option('static-dir');
 
         if (Str::startsWith($outputDir, '/')) {
             $outputDir = Str::after($outputDir, '/');
@@ -65,16 +63,10 @@ class Publish extends Command
 
         $process = ['npm', 'run', 'build-storybook'];
 
-        if ($outputDir || $staticDir) {
+        if ($outputDir) {
             $process[] = '--';
 
-            if ($outputDir) {
-                $process = array_merge($process, ['-o', $outputDir]);
-            }
-
-            if ($staticDir) {
-                $process = array_merge($process, ['-s', base_path($staticDir)]);
-            }
+            $process = array_merge($process, ['-o', $outputDir]);
         }
 
         $this->runProcessInBlast($process, true, [

--- a/src/Commands/Publish.php
+++ b/src/Commands/Publish.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace A17\Blast\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use A17\Blast\Traits\Helpers;
+
+class Publish extends Command
+{
+    use Helpers;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'blast:publish
+                                {--o|output-dir=storybook-static : Directory where to store built files}
+                                {--s|static-dir= : Directory where to load static files from relative to project root, comma-separated list}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Build Static Storybook Instance.';
+
+    /**
+     * @var Filesystem
+     */
+    protected $filesystem;
+
+    /**
+     * @param Filesystem $filesystem
+     */
+    public function __construct(Filesystem $filesystem)
+    {
+        parent::__construct();
+
+        $this->filesystem = $filesystem;
+        $this->storybookServer = config('blast.storybook_server_url');
+        $this->vendorPath = config('blast.vendor_path');
+        $this->storybookStatuses = config('blast.storybook_statuses');
+        $this->storybookTheme = config('blast.storybook_theme', false);
+    }
+
+    /*
+     * Executes the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $outputDir = $this->option('output-dir');
+        $staticDir = $this->option('static-dir');
+
+        if (Str::startsWith($outputDir, '/')) {
+            $outputDir = Str::after($outputDir, '/');
+        }
+
+        $this->info('Starting static Storybook build..');
+
+        $process = ['npm', 'run', 'build-storybook'];
+
+        if ($outputDir || $staticDir) {
+            $process[] = '--';
+
+            if ($outputDir) {
+                $process = array_merge($process, ['-o', $outputDir]);
+            }
+
+            if ($staticDir) {
+                $process = array_merge($process, ['-s', base_path($staticDir)]);
+            }
+        }
+
+        $this->runProcessInBlast($process, true, [
+            'STORYBOOK_SERVER_URL' => $this->storybookServer,
+            'STORYBOOK_STATUSES' => json_encode($this->storybookStatuses),
+            'STORYBOOK_THEME' => json_encode($this->storybookTheme),
+            'LIBSTORYPATH' => base_path($this->vendorPath . '/stories'),
+            'PROJECTPATH' => base_path(),
+            'COMPONENTPATH' => base_path('resources/views/stories'),
+        ]);
+
+        $this->info('Copying static build to `/public/' . $outputDir . '`..');
+
+        $this->info('View at ' . url($outputDir . '/index.html'));
+
+        $outputPath = $this->vendorPath . '/' . $outputDir;
+        $destPath = public_path($outputDir);
+
+        $this->CopyDirectory($outputPath, $destPath);
+    }
+}

--- a/src/Traits/Helpers.php
+++ b/src/Traits/Helpers.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace A17\Blast\Traits;
+
+use Symfony\Component\Process\Process;
+
+trait Helpers
+{
+    /**
+     * @return void
+     */
+    private function runProcessInBlast(
+        array $command,
+        $disableTimeout = false,
+        $envVars = null,
+    ) {
+        $process = new Process(
+            $command,
+            base_path($this->vendorPath),
+            $envVars,
+        );
+        $process->setTty(Process::isTtySupported());
+
+        if ($disableTimeout) {
+            $process->setTimeout(null);
+        } else {
+            $process->setTimeout(config('blast.build_timeout', 300));
+        }
+
+        $process->mustRun();
+    }
+
+    /**
+     * @return void
+     */
+    private function CopyDirectory($from, $to, $cleanDir = false)
+    {
+        $this->filesystem->ensureDirectoryExists($to);
+
+        if ($cleanDir) {
+            $this->filesystem->cleanDirectory($to);
+        }
+
+        if ($this->filesystem->exists($from)) {
+            $this->filesystem->copyDirectory($from, $to);
+        }
+    }
+}


### PR DESCRIPTION
Added a `blast:publish` command to build static storybook app and publish to public folder with options for setting the output directory and static assets path.