### PR TITLE
Update prettierrc to php 7.3 and tidy files to remove php 8 requirement

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-    "phpVersion": "8.0",
+    "phpVersion": "7.3",
     "semi": true,
     "arrowParens": "always",
     "singleQuote": true,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "stylelint": "stylelint",
         "stylelint:all": "stylelint ./resources/**/*.css",
         "prettier": "prettier",
-        "prettier:php": "prettier --write -- ./src/**/*.php"
+        "prettier:php": "prettier --write -- \"./src/**/*.php\""
     },
     "devDependencies": {
         "@babel/core": "^7.15.0",

--- a/src/BlastServiceProvider.php
+++ b/src/BlastServiceProvider.php
@@ -59,7 +59,7 @@ final class BlastServiceProvider extends ServiceProvider
     private function bootBladeComponents(): void
     {
         $this->callAfterResolving(BladeCompiler::class, function (
-            BladeCompiler $blade,
+            BladeCompiler $blade
         ) {
             $prefix = config('blast.prefix', '');
 

--- a/src/Components/DocsPages/DocsPage.php
+++ b/src/Components/DocsPages/DocsPage.php
@@ -19,7 +19,7 @@ class DocsPage extends Component
     public function __construct(
         $label = null,
         $title = null,
-        $description = null,
+        $description = null
     ) {
         $this->label = $label;
         $this->title = $title;

--- a/src/Traits/Helpers.php
+++ b/src/Traits/Helpers.php
@@ -12,7 +12,7 @@ trait Helpers
     private function runProcessInBlast(
         array $command,
         $disableTimeout = false,
-        $envVars = null,
+        $envVars = null
     ) {
         $process = new Process(
             $command,


### PR DESCRIPTION
Prettier was adding trailing commas in functions. Updated to use 7.3.