### PR TITLE
Autoload assets from mix-manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Set the background color of the component canvas area. The Storybook theme doesn
 
 Default: `''`
 
+#### `autoload_assets`
+
+Blast will attempt to autoload assets from a `mix-manifest.json` if the assets arrays are empty. This option allows you to disable that functionality.
+
+Default: `true`
+
 #### `assets`
 
 An array of urls to the `css` and `js` used by your components. The `css` and `js` urls are seperated out as the `css` is included in the head and the `js` is included before the closing `body` tag. You will most likely need to configure this after installing the package.

--- a/config/blast.php
+++ b/config/blast.php
@@ -10,6 +10,9 @@ return [
     // set the background color of the storybook canvas area
     'canvas_bg_color' => '',
 
+    // Blast will attempt to autoload assets from a mix-manifest if the assets arrays are empty. This option allows you to disable that functionality
+    'autoload_assets' => true,
+
     'assets' => [
         'css' => [],
         'js' => [],

--- a/src/BlastServiceProvider.php
+++ b/src/BlastServiceProvider.php
@@ -103,8 +103,8 @@ final class BlastServiceProvider extends ServiceProvider
 
     private function setAssetsFromMix(): void
     {
-        // bail early if assets are already set
-        if ($this->areAssetsSet()) {
+        // bail early if autoload disabled or assets are already set
+        if (!config('blast.autoload_assets') || $this->areAssetsSet()) {
             return;
         }
 


### PR DESCRIPTION
Added functionality to autoload css and js assets from mix-manifest.json if one exists if the config doesn't already have assets defined.

Resolves #5 