### PR TITLE
tidy up install method in Launch and add to Publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "@area17/blast",
-            "version": "1.0.1",
+            "version": "1.0.0",
             "dependencies": {
                 "@etchteam/storybook-addon-status": "^4.0.0",
                 "@storybook/addon-a11y": "^6.3.7",

--- a/src/Traits/Helpers.php
+++ b/src/Traits/Helpers.php
@@ -15,11 +15,7 @@ trait Helpers
         $disableTimeout = false,
         $envVars = null
     ) {
-        $process = new Process(
-            $command,
-            $this->vendorPath,
-            $envVars,
-        );
+        $process = new Process($command, $this->vendorPath, $envVars);
         $process->setTty(Process::isTtySupported());
 
         if ($disableTimeout) {
@@ -61,5 +57,35 @@ trait Helpers
         }
 
         return base_path($vendorPath);
+    }
+
+    private function dependenciesInstalled()
+    {
+        return $this->filesystem->exists(
+            $this->vendorPath . '/node_modules/@storybook',
+        );
+    }
+
+    private function getInstallMessage($npmInstall)
+    {
+        $depsInstalled = $this->dependenciesInstalled();
+
+        return ($npmInstall || (!$npmInstall && !$depsInstalled)
+            ? 'Installing'
+            : 'Reusing') . ' npm dependencies...';
+    }
+
+    private function installDependencies($npmInstall)
+    {
+        $depsInstalled = $this->dependenciesInstalled();
+
+        if ($npmInstall || (!$npmInstall && !$depsInstalled)) {
+            $this->runProcessInBlast([
+                'npm',
+                'ci',
+                '--production',
+                '--ignore-scripts',
+            ]);
+        }
     }
 }


### PR DESCRIPTION
Updated the `Publish` task so it now runs the same install check and method as the `Launch` so you can publish a static storybook app without needing to run the `Launch` task first.

Also tidied things up a bit to avoid repeating code.

Resolves #8 