### PR TITLE
Add source code tab to panel and docs page

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,7 +6,8 @@ module.exports = {
     '@storybook/addon-essentials',
     '@storybook/addon-a11y',
     'storybook-addon-designs',
-    '@etchteam/storybook-addon-status'
+    '@etchteam/storybook-addon-status',
+    'storybook-source-code-addon'
   ],
   core: {
     builder: 'webpack5'

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
                 "@storybook/server": "^6.3.7",
                 "chokidar-cli": "^3.0.0",
                 "concurrently": "^6.2.1",
-                "storybook-addon-designs": "^6.0.1"
+                "storybook-addon-designs": "^6.0.1",
+                "storybook-source-code-addon": "^1.2.0"
             },
             "devDependencies": {
                 "@babel/core": "^7.15.0",
@@ -9250,6 +9251,14 @@
                 "node": ">=4"
             }
         },
+        "node_modules/axios": {
+            "version": "0.21.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+            "dependencies": {
+                "follow-redirects": "^1.14.0"
+            }
+        },
         "node_modules/babel-loader": {
             "version": "8.2.2",
             "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.2.tgz",
@@ -13817,7 +13826,6 @@
             "version": "1.14.4",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
             "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -23531,6 +23539,67 @@
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0",
                 "react-dom": "^16.8.0 || ^17.0.0"
+            }
+        },
+        "node_modules/storybook-source-code-addon": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/storybook-source-code-addon/-/storybook-source-code-addon-1.2.0.tgz",
+            "integrity": "sha512-cgzWHFHyuypn6l8rA3uSPn8INZ+sB9ghzPERQS6VvNNdyj3C87lEMr+GGVcayT4sE+YPBfgH+8Y1S2S6wn5NIw==",
+            "dependencies": {
+                "@babel/preset-react": "^7.12.13",
+                "axios": "^0.21.1",
+                "react": "^17.0.1",
+                "react-dom": "^17.0.1",
+                "react-syntax-highlighter": "^15.4.3"
+            }
+        },
+        "node_modules/storybook-source-code-addon/node_modules/react": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+            "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+            "dependencies": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/storybook-source-code-addon/node_modules/react-dom": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+            "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+            "dependencies": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1",
+                "scheduler": "^0.20.2"
+            },
+            "peerDependencies": {
+                "react": "17.0.2"
+            }
+        },
+        "node_modules/storybook-source-code-addon/node_modules/react-syntax-highlighter": {
+            "version": "15.4.4",
+            "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.4.4.tgz",
+            "integrity": "sha512-PsOFHNTzkb3OroXdoR897eKN5EZ6grht1iM+f1lJSq7/L0YVnkJaNVwC3wEUYPOAmeyl5xyer1DjL6MrumO6Zw==",
+            "dependencies": {
+                "@babel/runtime": "^7.3.1",
+                "highlight.js": "^10.4.1",
+                "lowlight": "^1.17.0",
+                "prismjs": "^1.22.0",
+                "refractor": "^3.2.0"
+            },
+            "peerDependencies": {
+                "react": ">= 0.14.0"
+            }
+        },
+        "node_modules/storybook-source-code-addon/node_modules/scheduler": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+            "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+            "dependencies": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1"
             }
         },
         "node_modules/stream-browserify": {
@@ -34168,6 +34237,14 @@
             "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.3.tgz",
             "integrity": "sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA=="
         },
+        "axios": {
+            "version": "0.21.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+            "requires": {
+                "follow-redirects": "^1.14.0"
+            }
+        },
         "babel-loader": {
             "version": "8.2.2",
             "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.2.tgz",
@@ -37710,8 +37787,7 @@
         "follow-redirects": {
             "version": "1.14.4",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==",
-            "dev": true
+            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
         },
         "for-in": {
             "version": "1.0.2",
@@ -44996,6 +45072,60 @@
                 "@storybook/components": "^6.3.0",
                 "@storybook/core-events": "^6.3.0",
                 "ts-dedent": "^2.1.1"
+            }
+        },
+        "storybook-source-code-addon": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/storybook-source-code-addon/-/storybook-source-code-addon-1.2.0.tgz",
+            "integrity": "sha512-cgzWHFHyuypn6l8rA3uSPn8INZ+sB9ghzPERQS6VvNNdyj3C87lEMr+GGVcayT4sE+YPBfgH+8Y1S2S6wn5NIw==",
+            "requires": {
+                "@babel/preset-react": "^7.12.13",
+                "axios": "^0.21.1",
+                "react": "^17.0.1",
+                "react-dom": "^17.0.1",
+                "react-syntax-highlighter": "^15.4.3"
+            },
+            "dependencies": {
+                "react": {
+                    "version": "17.0.2",
+                    "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+                    "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1"
+                    }
+                },
+                "react-dom": {
+                    "version": "17.0.2",
+                    "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+                    "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1",
+                        "scheduler": "^0.20.2"
+                    }
+                },
+                "react-syntax-highlighter": {
+                    "version": "15.4.4",
+                    "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.4.4.tgz",
+                    "integrity": "sha512-PsOFHNTzkb3OroXdoR897eKN5EZ6grht1iM+f1lJSq7/L0YVnkJaNVwC3wEUYPOAmeyl5xyer1DjL6MrumO6Zw==",
+                    "requires": {
+                        "@babel/runtime": "^7.3.1",
+                        "highlight.js": "^10.4.1",
+                        "lowlight": "^1.17.0",
+                        "prismjs": "^1.22.0",
+                        "refractor": "^3.2.0"
+                    }
+                },
+                "scheduler": {
+                    "version": "0.20.2",
+                    "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+                    "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1"
+                    }
+                }
             }
         },
         "stream-browserify": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
         "@storybook/server": "^6.3.7",
         "chokidar-cli": "^3.0.0",
         "concurrently": "^6.2.1",
-        "storybook-addon-designs": "^6.0.1"
+        "storybook-addon-designs": "^6.0.1",
+        "storybook-source-code-addon": "^1.2.0"
     },
     "lint-staged": {
         "*.js": "eslint --no-fix",

--- a/src/Commands/GenerateStories.php
+++ b/src/Commands/GenerateStories.php
@@ -305,15 +305,11 @@ class GenerateStories extends Command
                     'id' => str_replace('.blade.php', '', $item['path']),
                 ],
                 'componentSource' => [
-                    'code' => $this->getCodeSnippet(
-                        $this->storyViewsPath . '/' . $item['path'],
-                    ),
+                    'code' => $this->getCodeSnippet($item['path']),
                 ],
                 'docs' => [
                     'source' => [
-                        'code' => $this->getCodeSnippet(
-                            $this->storyViewsPath . '/' . $item['path'],
-                        ),
+                        'code' => $this->getCodeSnippet($item['path']),
                     ],
                 ],
             ],
@@ -465,8 +461,11 @@ class GenerateStories extends Command
 
     private function getCodeSnippet($filepath)
     {
+        $filepath =
+            $this->storyViewsPath . '/' . Str::finish($filepath, '.blade.php');
+
         if (!$this->filesystem->exists($filepath)) {
-            return [];
+            return false;
         }
 
         $contents = $this->filesystem->get($filepath);

--- a/src/Commands/GenerateStories.php
+++ b/src/Commands/GenerateStories.php
@@ -304,6 +304,18 @@ class GenerateStories extends Command
                 'server' => [
                     'id' => str_replace('.blade.php', '', $item['path']),
                 ],
+                'componentSource' => [
+                    'code' => $this->getCodeSnippet(
+                        $this->storyViewsPath . '/' . $item['path'],
+                    ),
+                ],
+                'docs' => [
+                    'source' => [
+                        'code' => $this->getCodeSnippet(
+                            $this->storyViewsPath . '/' . $item['path'],
+                        ),
+                    ],
+                ],
             ],
         ];
 
@@ -449,5 +461,18 @@ class GenerateStories extends Command
                 return $story['order'] ?? $story['name'];
             }),
         );
+    }
+
+    private function getCodeSnippet($filepath)
+    {
+        if (!$this->filesystem->exists($filepath)) {
+            return [];
+        }
+
+        $contents = $this->filesystem->get($filepath);
+
+        $snippet = preg_replace('/@storybook\(\[(.*)\]\)/sU', '', $contents);
+
+        return trim($snippet);
     }
 }


### PR DESCRIPTION
From #23
Added the story code snippets tab to the panel in the story view (https://storybook.js.org/addons/@storybook/addon-storysource) and also in the docs view.

The code view removes the `@storybook` block at the top of the stories 