### PR TITLE
Add UI theming and expanded control documentation

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,8 +1,8 @@
 import { addons } from '@storybook/addons';
 import { themes } from '@storybook/theming';
-// import theme from './theme';
+import theme from './theme';
 
-let configTheme = JSON.parse(process.env.STORYBOOK_THEME);
+const configTheme = JSON.parse(process.env.STORYBOOK_THEME);
 
 let storybookTheme = () => {
   if (configTheme === "dark") {
@@ -13,7 +13,6 @@ let storybookTheme = () => {
 }
 
 let customTheme = () => {
-  console.log(theme)
   addons.setConfig({ theme });
 }
 

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,9 +1,24 @@
-
 import { addons } from '@storybook/addons';
-import theme from './theme';
+import { themes } from '@storybook/theming';
+// import theme from './theme';
 
-if(process.env.STORYBOOK_THEME){
-  addons.setConfig({
-    theme,
-  });
+let configTheme = JSON.parse(process.env.STORYBOOK_THEME);
+
+let storybookTheme = () => {
+  if (configTheme === "dark") {
+    addons.setConfig({ theme: themes.dark });
+  } else {
+    addons.setConfig({ theme: themes.normal });
+  }
+}
+
+let customTheme = () => {
+  console.log(theme)
+  addons.setConfig({ theme });
+}
+
+if (configTheme === "custom") {
+  customTheme();
+} else {
+  storybookTheme();
 }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,7 @@
 export const parameters = {
+  controls: {
+    expanded: true
+  },
   server: {
     url: process.env.STORYBOOK_SERVER_URL
   },

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,16 @@
+import { themes } from '@storybook/theming';
+
+let setDocsTheme = (configDocsTheme) => {
+  if (configDocsTheme === "dark") {
+    return themes.dark;
+  } else {
+    return themes.normal;
+  }
+}
+
 export const parameters = {
   controls: {
-    expanded: true
+    expanded: JSON.parse(process.env.STORYBOOK_EXPANDED_CONTROLS),
   },
   server: {
     url: process.env.STORYBOOK_SERVER_URL
@@ -15,7 +25,8 @@ export const parameters = {
         return typeof notes === 'string' ? notes : notes.markdown || notes.text;
       }
       return null;
-    }
+    },
+    theme: setDocsTheme(JSON.parse(process.env.STORYBOOK_DOCS_THEME)),
   },
   options: {
     storySort: {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,8 +1,11 @@
 import { themes } from '@storybook/theming';
+import theme from './theme';
 
 let setDocsTheme = (configDocsTheme) => {
   if (configDocsTheme === "dark") {
     return themes.dark;
+  } else if (configDocsTheme === 'custom') {
+    return theme;
   } else {
     return themes.normal;
   }

--- a/config/blast.php
+++ b/config/blast.php
@@ -4,40 +4,46 @@ return [
     'storybook_server_url' =>
         env('STORYBOOK_SERVER_HOST', env('APP_URL')) . 'storybook_preview',
     
-    // 
-    'expanded_controls' => true,
+    /**
+     * See https://storybook.js.org/docs/react/essentials/controls Set
+     * to true to enable full documentation on the controls tab. 
+     */
+    'storybook_expanded_controls' => true,
 
     /**
-     * See https://storybook.js.org/docs/react/configure/theming for detail
-     * dark, normal, custom. Dark and Normal (light) are out of the box
-     * from @storybook-theming. For Custom replace values in
-     * 'custom_theme' to create a custom theme
+     * See https://storybook.js.org/docs/react/configure/theming for
+     * detail - dark, normal, custom. Dark and normal are out of
+     * the box from @storybook-theming. For custom edit the
+     * values in 'custom_theme' to create a custom theme
      */
     'storybook_theme' => 'dark',
 
-    // 'custom_theme' => [
-    //     'base' => 'light',
-    //     'colorPrimary' => 'hotpink',
-    //     'colorSecondary' => 'deepskyblue',
-    //     'appBg' => 'white',
-    //     'appContentBg' => 'silver',
-    //     'appBorderColor' => 'grey',
-    //     'appBorderRadius' => 4,
-    //     'fontBase' => '"Open Sans", sans-serif',
-    //     'fontCode' => 'monospace',
-    //     'textColor' => 'black',
-    //     'textInverseColor' => 'rgba(255,255,255,0.9)',
-    //     'barTextColor' => 'silver',
-    //     'barSelectedColor' => 'black',
-    //     'barBg' => 'hotpink',
-    //     'inputBg' => 'white',
-    //     'inputBorder' => 'silver',
-    //     'inputTextColor' => 'black',
-    //     'inputBorderRadius' => 4,
-    //     'brandTitle' => 'My custom storybook',
-    //     'brandUrl' => 'https://example.com',
-    //     'brandImage' => 'https://place-hold.it/350x150'
-    // ],
+    'storybook_custom_theme' => [
+        'base' => 'light',
+        'colorPrimary' => 'hotpink',
+        'colorSecondary' => 'deepskyblue',
+        'appBg' => 'white',
+        'appContentBg' => 'silver',
+        'appBorderColor' => 'grey',
+        'appBorderRadius' => 4,
+        'fontBase' => '"Open Sans", sans-serif',
+        'fontCode' => 'monospace',
+        'textColor' => 'black',
+        'textInverseColor' => 'rgba(255,255,255,0.9)',
+        'barTextColor' => 'silver',
+        'barSelectedColor' => 'black',
+        'barBg' => 'hotpink',
+        'inputBg' => 'white',
+        'inputBorder' => 'silver',
+        'inputTextColor' => 'black',
+        'inputBorderRadius' => 4,
+        'brandTitle' => 'My custom storybook',
+        'brandUrl' => 'https://example.com',
+        'brandImage' => 'https://place-hold.it/350x150'
+    ],
+
+    // dark or normal
+    'storybook_docs_theme' => 'dark',
 
     // set the background color of the storybook canvas area
     'canvas_bg_color' => '',

--- a/config/blast.php
+++ b/config/blast.php
@@ -16,34 +16,34 @@ return [
      * the box from @storybook-theming. For custom edit the
      * values in 'custom_theme' to create a custom theme
      */
-    'storybook_theme' => 'dark',
+    'storybook_theme' => 'custom',
 
     'storybook_custom_theme' => [
-        'base' => 'light',
-        'colorPrimary' => 'hotpink',
-        'colorSecondary' => 'deepskyblue',
-        'appBg' => 'white',
-        'appContentBg' => 'silver',
-        'appBorderColor' => 'grey',
+        'base' => 'lightgray',
+        'colorPrimary' => 'cadetblue',
+        'colorSecondary' => 'lightcoral',
+        'appBg' => 'whitesmoke',
+        'appContentBg' => 'gainsboro',
+        'appBorderColor' => 'ghostwhite',
         'appBorderRadius' => 4,
-        'fontBase' => '"Open Sans", sans-serif',
+        'fontBase' => '"Nunito", sans-serif',
         'fontCode' => 'monospace',
-        'textColor' => 'black',
-        'textInverseColor' => 'rgba(255,255,255,0.9)',
-        'barTextColor' => 'silver',
-        'barSelectedColor' => 'black',
-        'barBg' => 'hotpink',
-        'inputBg' => 'white',
-        'inputBorder' => 'silver',
-        'inputTextColor' => 'black',
+        'textColor' => 'darkslategrey',
+        'textInverseColor' => 'darkgrey',
+        'barTextColor' => 'white',
+        'barSelectedColor' => 'ghostwhite',
+        'barBg' => 'cadetblue',
+        'inputBg' => 'ghostwhite',
+        'inputBorder' => 'ghostwhite',
+        'inputTextColor' => 'darkslategrey',
         'inputBorderRadius' => 4,
-        'brandTitle' => 'My custom storybook',
-        'brandUrl' => 'https://example.com',
-        'brandImage' => 'https://place-hold.it/350x150'
+        'brandTitle' => 'Blast storybook for blade',
+        'brandUrl' => '#',
+        'brandImage' => 'https://i.gifer.com/nN2.gif'
     ],
 
     // dark or normal
-    'storybook_docs_theme' => 'dark',
+    'storybook_docs_theme' => 'custom',
 
     // set the background color of the storybook canvas area
     'canvas_bg_color' => '',

--- a/config/blast.php
+++ b/config/blast.php
@@ -2,10 +2,42 @@
 
 return [
     'storybook_server_url' =>
-        env('STORYBOOK_SERVER_HOST', env('APP_URL')) . '/storybook_preview',
+        env('STORYBOOK_SERVER_HOST', env('APP_URL')) . 'storybook_preview',
+    
+    // 
+    'expanded_controls' => true,
 
-    // See https://storybook.js.org/docs/react/configure/theming for available options
-    'storybook_theme' => [],
+    /**
+     * See https://storybook.js.org/docs/react/configure/theming for detail
+     * dark, normal, custom. Dark and Normal (light) are out of the box
+     * from @storybook-theming. For Custom replace values in
+     * 'custom_theme' to create a custom theme
+     */
+    'storybook_theme' => 'dark',
+
+    // 'custom_theme' => [
+    //     'base' => 'light',
+    //     'colorPrimary' => 'hotpink',
+    //     'colorSecondary' => 'deepskyblue',
+    //     'appBg' => 'white',
+    //     'appContentBg' => 'silver',
+    //     'appBorderColor' => 'grey',
+    //     'appBorderRadius' => 4,
+    //     'fontBase' => '"Open Sans", sans-serif',
+    //     'fontCode' => 'monospace',
+    //     'textColor' => 'black',
+    //     'textInverseColor' => 'rgba(255,255,255,0.9)',
+    //     'barTextColor' => 'silver',
+    //     'barSelectedColor' => 'black',
+    //     'barBg' => 'hotpink',
+    //     'inputBg' => 'white',
+    //     'inputBorder' => 'silver',
+    //     'inputTextColor' => 'black',
+    //     'inputBorderRadius' => 4,
+    //     'brandTitle' => 'My custom storybook',
+    //     'brandUrl' => 'https://example.com',
+    //     'brandImage' => 'https://place-hold.it/350x150'
+    // ],
 
     // set the background color of the storybook canvas area
     'canvas_bg_color' => '',
@@ -42,12 +74,6 @@ return [
             'description' => 'This component is stable and released',
         ],
     ],
-
-    'storybook_global_types' => [],
-
-    // set a global custom order for stories in the Storybook UI
-    // More info - https://storybook.js.org/docs/react/writing-stories/naming-components-and-hierarchy#sorting-stories
-    'storybook_sort_order' => [],
 
     'build_timeout' => 300,
 

--- a/src/Commands/GenerateStories.php
+++ b/src/Commands/GenerateStories.php
@@ -382,7 +382,7 @@ class GenerateStories extends Command
             }
 
             if (Arr::has($options, 'order')) {
-                $data['order'] = $options['order'];
+                $data['order'] = (float) $options['order'];
             }
         }
 

--- a/src/Commands/GenerateStories.php
+++ b/src/Commands/GenerateStories.php
@@ -382,7 +382,7 @@ class GenerateStories extends Command
             }
 
             if (Arr::has($options, 'order')) {
-                $data['order'] = (float) $options['order'];
+                $data['order'] = $options['order'];
             }
         }
 

--- a/src/Commands/Launch.php
+++ b/src/Commands/Launch.php
@@ -43,7 +43,10 @@ class Launch extends Command
         $this->storybookServer = config('blast.storybook_server_url');
         $this->vendorPath = $this->getVendorPath();
         $this->storybookStatuses = config('blast.storybook_statuses');
-        $this->storybookTheme = config('blast.storybook_theme', false);
+        $this->storybookTheme = config('blast.storybook_theme', 'normal');
+        $this->customTheme = config('blast.storybook_custom_theme', false);
+        $this->docsTheme = config('blast.storybook_docs_theme', 'normal');
+        $this->expandedControls = config('blast.storybook_expanded_controls');
         $this->storybookGlobalTypes = config(
             'blast.storybook_global_types',
             [],
@@ -126,6 +129,9 @@ class Launch extends Command
             'STORYBOOK_STATIC_PATH' => public_path(),
             'STORYBOOK_STATUSES' => json_encode($this->storybookStatuses),
             'STORYBOOK_THEME' => json_encode($this->storybookTheme),
+            'STORYBOOK_CUSTOM_THEME' => json_encode($this->customTheme),
+            'STORYBOOK_DOCS_THEME' => json_encode($this->docsTheme),
+            'STORYBOOK_EXPANDED_CONTROLS' => json_encode($this->expandedControls),
             'STORYBOOK_GLOBAL_TYPES' => json_encode(
                 $this->storybookGlobalTypes,
             ),

--- a/src/Commands/Publish.php
+++ b/src/Commands/Publish.php
@@ -48,6 +48,7 @@ class Publish extends Command
         $this->customTheme = config('blast.storybook_custom_theme', false);
         $this->docsTheme = config('blast.storybook_docs_theme', 'normal');
         $this->expandedControls = config('blast.storybook_expanded_controls');
+        $this->storybookSortOrder = config('blast.storybook_sort_order', []);
         $this->storybookGlobalTypes = config(
             'blast.storybook_global_types',
             [],
@@ -121,6 +122,7 @@ class Publish extends Command
             'LIBSTORYPATH' => $this->vendorPath . '/stories',
             'PROJECTPATH' => base_path(),
             'COMPONENTPATH' => base_path('resources/views/stories'),
+            'STORYBOOK_SORT_ORDER' => json_encode($this->storybookSortOrder),
         ]);
 
         usleep(250000);

--- a/src/Commands/Publish.php
+++ b/src/Commands/Publish.php
@@ -45,6 +45,9 @@ class Publish extends Command
         $this->vendorPath = $this->getVendorPath();
         $this->storybookStatuses = config('blast.storybook_statuses');
         $this->storybookTheme = config('blast.storybook_theme', false);
+        $this->customTheme = config('blast.storybook_custom_theme', false);
+        $this->docsTheme = config('blast.storybook_docs_theme', 'normal');
+        $this->expandedControls = config('blast.storybook_expanded_controls');
         $this->storybookGlobalTypes = config(
             'blast.storybook_global_types',
             [],
@@ -109,6 +112,9 @@ class Publish extends Command
             'STORYBOOK_SERVER_URL' => $this->storybookServer,
             'STORYBOOK_STATUSES' => json_encode($this->storybookStatuses),
             'STORYBOOK_THEME' => json_encode($this->storybookTheme),
+            'STORYBOOK_CUSTOM_THEME' => json_encode($this->customTheme),
+            'STORYBOOK_DOCS_THEME' => json_encode($this->docsTheme),
+            'STORYBOOK_EXPANDED_CONTROLS' => json_encode($this->expandedControls),
             'STORYBOOK_GLOBAL_TYPES' => json_encode(
                 $this->storybookGlobalTypes,
             ),


### PR DESCRIPTION
Not Ready to Merge - I want to add a better example of a custom theme and add custom theme to docs page first.

Hi, I've opened this pull request to add the ability to change theme from blast.php between default(light) and dark theme for both the canvas and docs pages. Also included within the PR is the ability to defne a custom theme from blast.php

Another addition is to enable expanded documentation in the controls tab via a bool in blast.php. To render the description add 'description' to argTypes within @storybook blade directive, e.g.

```
@storybook([
    'name' => 'Theme Toggle',
    'status' => 'readyForQA',
    'design' => "",
    'args' => [
        'label' => 'Theme',
        'color' => 'text-muted'
    ],
    'argTypes' => [
        'label' => [
            'options' => [
                'Theme', 'Color Theme', 'Colour Theme', 'Dark Mode' 
            ],
            'control' => [
                'type' => 'select'
            ],
            'description' => 'label to the right of the toggle switch',
            'defaultValue' => 'Theme',
            'table' => [
                'type' => [
                    'summary' => 'string'
                ],
                'defaultValue' => [
                    'summary' => 'Theme'
                ],
            ],
        ],
        'color' =>[
            'options' => [
                'text-light', 'text-primary', 'text-dark', 'text-dark'
            ],
            'control' => [
                'type' => 'select'
        ],
        'description' => 'bootstrap 5 classes for text-color',
        'defaultValue' => 'text-muted',
        'table' => [
            'type' => [
                'summary' => 'string'
            ],
            'defaultValue' => [
                'summary' => 'text-muted'
            ],
        ],
        ]
    ]
])
```
![Storybook_custom_theme_docs_page](https://user-images.githubusercontent.com/59289145/141648573-994daf20-2914-482c-870c-a34c3863fca3.JPG)
![Storybook_custom_theme_expanded_controls](https://user-images.githubusercontent.com/59289145/141648574-c8c058e6-7aa7-4cbd-8f13-85d626748059.JPG)
