### PR TITLE
Create DataStore facade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,10 @@
         "laravel": {
             "providers": [
                 "A17\\Blast\\BlastServiceProvider"
-            ]
+            ],
+            "aliases": {
+                "DataStore": "A17\\Blast\\Facades\\DataStore"
+            }
         }
     },
     "autoload-dev": {

--- a/src/BlastServiceProvider.php
+++ b/src/BlastServiceProvider.php
@@ -2,15 +2,17 @@
 
 namespace A17\Blast;
 
+use A17\Blast\DataStore;
+use Illuminate\Support\Str;
 use A17\Blast\Commands\Demo;
-use A17\Blast\Commands\GenerateStories;
-use A17\Blast\Commands\GenerateUIDocs;
 use A17\Blast\Commands\Launch;
 use A17\Blast\Commands\Publish;
 use Illuminate\Support\Facades\Blade;
+use A17\Blast\Commands\GenerateUIDocs;
+use A17\Blast\Commands\GenerateStories;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\BladeCompiler;
-use Illuminate\Support\Str;
 
 final class BlastServiceProvider extends ServiceProvider
 {
@@ -18,6 +20,7 @@ final class BlastServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__ . '/../config/blast.php', 'blast');
         $this->registerCommands();
+        $this->registerServices();
     }
 
     public function boot(): void
@@ -41,6 +44,13 @@ final class BlastServiceProvider extends ServiceProvider
                 Publish::class,
             ]);
         }
+    }
+
+    private function registerServices(): void
+    {
+        $this->app->singleton('blast.datastore', function () {
+            return new DataStore($this->app->make(FileSystem::class));
+        });
     }
 
     private function bootResources(): void

--- a/src/Commands/GenerateStories.php
+++ b/src/Commands/GenerateStories.php
@@ -6,7 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use A17\Blast\DataStore;
+use A17\Blast\Facades\DataStore;
 use A17\Blast\Traits\Helpers;
 
 class GenerateStories extends Command
@@ -33,18 +33,12 @@ class GenerateStories extends Command
     protected $filesystem;
 
     /**
-     * @var DataStore
-     */
-    protected $dataStore;
-
-    /**
      * @param Filesystem $filesystem
      */
-    public function __construct(Filesystem $filesystem, DataStore $dataStore)
+    public function __construct(Filesystem $filesystem)
     {
         parent::__construct();
 
-        $this->dataStore = $dataStore;
         $this->filesystem = $filesystem;
         $this->storyViewsPath = base_path('resources/views/stories');
         $this->vendorPath = $this->getVendorPath();
@@ -321,7 +315,7 @@ class GenerateStories extends Command
             $options = $item['options'];
 
             if (Arr::has($options, 'preset')) {
-                $preset = $this->dataStore->get($options['preset']);
+                $preset = DataStore::get($options['preset']);
 
                 if (is_array($preset) && !empty($preset)) {
                     foreach ($preset as $key => $settings) {
@@ -345,10 +339,10 @@ class GenerateStories extends Command
                 foreach ($presetArgs as $key => $preset) {
                     if (is_array($preset)) {
                         $args = array_map(function ($item) {
-                            return $this->dataStore->get($item)['args'] ?? [];
+                            return DataStore::get($item)['args'] ?? [];
                         }, $preset);
                     } else {
-                        $args = $this->dataStore->get($preset)['args'] ?? [];
+                        $args = DataStore::get($preset)['args'] ?? [];
                     }
 
                     $options['args'][$key] = $args;

--- a/src/DataStore.php
+++ b/src/DataStore.php
@@ -30,17 +30,22 @@ class DataStore
         $this->filesystem = $filesystem;
 
         $this->filesystem->ensureDirectoryExists($this->dataPath);
-        $this->getComponentsData();
     }
 
     public function get($key = null)
     {
+        $filename = explode('.', $key);
+
+        if (empty($this->data[$filename[0]])) {
+            $this->getComponentData($filename[0]);
+        }
+
         if ($key) {
             return Arr::get($this->data, $key);
         }
     }
 
-    private function getComponentsData()
+    private function getComponentData($key)
     {
         if (!$this->filesystem->exists($this->dataPath)) {
             return 1;
@@ -53,15 +58,18 @@ class DataStore
                 if ($file->getExtension() == 'php') {
                     $filename = str_replace('.php', '', $file->getFilename());
 
-                    $this->data[$filename] = include base_path(
-                        $file->getPathname(),
-                    );
+                    if ($key === $filename) {
+                        $this->data[$filename] = include base_path(
+                            $file->getPathname(),
+                        );
+                    }
                 }
             }
 
             $this->data = array_map([$this, 'parsePresetArgs'], $this->data);
         }
     }
+
     private function parsePresetArgs($data = null)
     {
         $parsed = array_map(function ($item) {

--- a/src/Facades/DataStore.php
+++ b/src/Facades/DataStore.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace A17\Blast\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class DataStore extends Facade
+{
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
+    protected static function getFacadeAccessor()
+    {
+        return 'blast.datastore';
+    }
+}


### PR DESCRIPTION
This PR creates a Facade `DataStore`. I changed the way the data sore loads its content. Instead of loading all files in `data/*.php` on init, it will try to load each file as they are requested, in order to be able to use the data store from within data files and prevent recursive loads.

The change to the data store should be optimized a bit further.

```php
<?php

use A17\Blast\Facades\DataStore;

$tag = DataStore::get('tag.base');

return [
    'artwork' => [
```