### PR TITLE
Add Twill Transformers support

### DIFF
--- a/src/BlastServiceProvider.php
+++ b/src/BlastServiceProvider.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\Support\Str;
+use A17\Blast\Support\Transformer;
 
 final class BlastServiceProvider extends ServiceProvider
 {
@@ -28,6 +29,7 @@ final class BlastServiceProvider extends ServiceProvider
         $this->bootRoutes();
         $this->bootPublishing();
         $this->setAssetsFromMix();
+        $this->bootTransformer();
     }
 
     private function registerCommands(): void
@@ -57,6 +59,10 @@ final class BlastServiceProvider extends ServiceProvider
     {
         Blade::directive('storybook', function () {
             return '';
+        });
+
+        Blade::directive('transformer', function ($contents) {
+            return app(Transformer::class)->compileTransformer($contents);
         });
     }
 
@@ -139,5 +145,12 @@ final class BlastServiceProvider extends ServiceProvider
 
         // if the count is greater than 0, we can assume that assets have been set
         return count(array_filter($assets)) > 0;
+    }
+
+    public function bootTransformer()
+    {
+        $this->app->singleton(Transformer::class, function ($app) {
+            return new Transformer();
+        });
     }
 }

--- a/src/Support/Transformer.php
+++ b/src/Support/Transformer.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace A17\Blast\Support;
+
+class Transformer
+{
+    public function compileTransformer($code)
+    {
+        $code = trim($code);
+
+        if (class_exists($code)) {
+            return '
+                <?php
+                    foreach('.$code.'::blast("'.$code.'", get_defined_vars()) as $var => $value) {
+                        $$var = $value;
+                    }
+                ?>
+            ';
+        }
+
+        return $code;
+    }
+
+    public static function transform($transformerClass, $bladeDefinedVars): array
+    {
+        $transformer = new $transformerClass();
+
+        $bladeDefinedVars['__blast'] = $transformer->setData($bladeDefinedVars['__data'])->transform();
+
+        if (
+            blank($bladeDefinedVars['__blast']) &&
+            method_exists($transformer, 'transformStorybookData')
+        ) {
+            $bladeDefinedVars['__blast'] = $transformer->transformStorybookData() ?? [];
+        }
+
+        return $bladeDefinedVars['__blast'];
+    }
+}


### PR DESCRIPTION
To use this on any Twill based application:

Add the transformer to your view using the `@transformer` directive. The `args` key can still be used on the `@storybook` directive, but the purpose here is to inject it from a transformer:

``` php
@transformer(App\Transformers\Posts)

@storybook([
    'layout' => 'fullscreen',
    'status' => 'dev',
    'args' => [],
])
```

Your base Transformer must call the Blast internal transformer:

``` php
public static function blast($transformer, $bladeDefinedVars): array
{
    return app(BlastTransformer::class)->transform($transformer, $bladeDefinedVars);
}
```

Then your transformer must define a `transformStorybookData()` method that will return the fake data:

``` php
<?php

namespace App\Transformers;

class Posts extends Transformer
{
    public function transform(): array
    {
        return [
            'title' => $this->title,
        ];
    }

    public function transformStorybookData(): array
    {
        return [
            'title' => 'Fake Title to Be Displayed Inside Storybook Only',
        ];
    }
}
```