### PR TITLE
Route middleware support

### DIFF
--- a/config/blast.php
+++ b/config/blast.php
@@ -126,6 +126,10 @@ return [
 
     'vendor_path' => 'vendor/area17/blast',
 
+    // Assign your own route middleware to the $storybook_server_url/{name?} routes
+    // Useful for CSRF, etc.
+    'route_middleware' => null,
+
     'components' => [
         'docs-page' => \A17\Blast\Components\DocsPages\DocsPage::class,
         'ui-colors' => \A17\Blast\Components\DocsPages\UiColors::class,

--- a/src/BlastServiceProvider.php
+++ b/src/BlastServiceProvider.php
@@ -8,6 +8,7 @@ use A17\Blast\Commands\GenerateUIDocs;
 use A17\Blast\Commands\Launch;
 use A17\Blast\Commands\Publish;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\Support\Str;
@@ -50,7 +51,15 @@ final class BlastServiceProvider extends ServiceProvider
 
     private function bootRoutes(): void
     {
-        $this->loadRoutesFrom(__DIR__ . '/../routes/web.php');
+        $middleware = config('blast.route_middleware', null);
+        Route::group(
+            [
+                'middleware' => $middleware,
+            ],
+            function () {
+                $this->loadRoutesFrom(__DIR__ . '/../routes/web.php');
+            },
+        );
     }
 
     private function bootBladeDirectives(): void


### PR DESCRIPTION
This PR allows the user to specify their own route middleware name, e.g. `web` (or their own custom blast-specific one), in order to hook into middleware on storybook preview requests.

Example use-case: I found that I needed this in order to use Livewire fetch requests within Storybook, as it was bypassing the CSRF middleware and failing.

While `web` might have been an acceptable config default, I went with `null` to be fully non-breaking.