### PR TITLE
Make storybook directive parsing more consistent with regular blade statements

### DIFF
--- a/src/Commands/GenerateStories.php
+++ b/src/Commands/GenerateStories.php
@@ -437,7 +437,7 @@ class GenerateStories extends Command
         // Regexp modifiers:
         //   `s`  allows newlines as part of the `.*` match
         //   `U`  stops the match at the first closing parenthesis
-        preg_match('/@storybook\(\[(.*)\]\)/sU', $contents, $matches);
+        preg_match('/@storybook[ \t]*\(\[(.*)\]\)/sU', $contents, $matches);
 
         if (!filled($matches)) {
             return [];


### PR DESCRIPTION
First of all, thank you for this package and the accompanying article 🙌 . We are looking into potentially using this in our projects.

One thing I noticed is that I could not use  `@storybook (['....'])` (notice the whitespace). This PR makes it more consistent with how Laravel parses such statements. I had to check, but yes, in fact Laravel does allow `@foreach         (...)`, not just zero or one spaces 😅; this change is straight from their parser.