### PR TITLE
Use base_path() for default data_path

### DIFF
--- a/src/DataStore.php
+++ b/src/DataStore.php
@@ -4,6 +4,7 @@ namespace A17\Blast;
 
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 class DataStore
 {
@@ -11,6 +12,11 @@ class DataStore
      * @var array
      */
     protected $data;
+
+    /**
+     * @var string
+     */
+    protected $dataPath;
 
     /**
      * @var Filesystem
@@ -23,10 +29,7 @@ class DataStore
     public function __construct(Filesystem $filesystem)
     {
         $this->data = [];
-        $this->dataPath = config(
-            'blast.data_path',
-            'resources/views/stories/data',
-        );
+        $this->dataPath = $this->getDataPath();
         $this->filesystem = $filesystem;
 
         $this->filesystem->ensureDirectoryExists($this->dataPath);
@@ -38,6 +41,20 @@ class DataStore
         if ($key) {
             return Arr::get($this->data, $key);
         }
+    }
+
+    private function getDataPath()
+    {
+        $dataPath = config(
+            'blast.data_path',
+            'resources/views/stories/data'
+        );
+
+        if (Str::startsWith($dataPath, '/')) {
+            return $dataPath;
+        }
+
+        return base_path($dataPath);
     }
 
     private function getComponentsData()
@@ -53,9 +70,7 @@ class DataStore
                 if ($file->getExtension() == 'php') {
                     $filename = str_replace('.php', '', $file->getFilename());
 
-                    $this->data[$filename] = include base_path(
-                        $file->getPathname(),
-                    );
+                    $this->data[$filename] = include $file->getPathname();
                 }
             }
 

--- a/tests/Feature/DataStoreTest.php
+++ b/tests/Feature/DataStoreTest.php
@@ -16,6 +16,7 @@ class DataStoreTest extends TestCase
         $this->writeExampleDataFile($path);
         Config::set('blast.data_path', $path);
         $this->assertEquals('bar', app(DataStore::class)->get('example.dummy.args.foo'));
+        $this->cleanup($path);
     }
 
     public function test_can_use_absolute_path()
@@ -24,6 +25,7 @@ class DataStoreTest extends TestCase
         $this->writeExampleDataFile($path);
         Config::set('blast.data_path', $path);
         $this->assertEquals('bar', app(DataStore::class)->get('example.dummy.args.foo'));
+        $this->cleanup($path);
     }
 
     public function test_default_path()
@@ -51,5 +53,13 @@ return [
 ];
 PHP
         );
+    }
+
+    private function cleanup(string $path)
+    {
+        if (! Str::startsWith($path, '/')) {
+            $path = base_path($path);
+        }
+        File::deleteDirectory($path);
     }
 }

--- a/tests/Feature/DataStoreTest.php
+++ b/tests/Feature/DataStoreTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature;
+
+use A17\Blast\DataStore;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class DataStoreTest extends TestCase
+{
+    public function test_can_use_relative_path()
+    {
+        $path = 'resources/views/stories/non-standard-relative';
+        $this->writeExampleDataFile($path);
+        Config::set('blast.data_path', $path);
+        $this->assertEquals('bar', app(DataStore::class)->get('example.dummy.args.foo'));
+    }
+
+    public function test_can_use_absolute_path()
+    {
+        $path = base_path('resources/views/stories/non-standard-absolute');
+        $this->writeExampleDataFile($path);
+        Config::set('blast.data_path', $path);
+        $this->assertEquals('bar', app(DataStore::class)->get('example.dummy.args.foo'));
+    }
+
+    public function test_default_path()
+    {
+        $path = base_path('resources/views/stories/data');
+        $this->writeExampleDataFile($path);
+        $this->assertEquals('bar', app(DataStore::class)->get('example.dummy.args.foo'));
+    }
+
+    private function writeExampleDataFile(string $path)
+    {
+        if (! Str::startsWith($path, '/')) {
+            $path = base_path($path);
+        }
+        File::ensureDirectoryExists($path);
+        File::put($path . '/example.php', <<<PHP
+<?php
+
+return [
+    'dummy' => [
+        'args' => [
+            'foo' => 'bar',
+        ],
+    ],
+];
+PHP
+        );
+    }
+}


### PR DESCRIPTION
This wraps the default value used for `data_path` with base_path(), which provides similar handling to what is being done in getVendorPath() already.

The relative data_path was causing an issue where when running a Laravel worker process, the relative path seemed to be relative to somewhere other than the base path and the worker didn't have permission to write there. This caused a fatal error similar to the one described in https://github.com/area17/blast/issues/61