### PR TITLE
Use FQCN for Str

### DIFF
--- a/resources/views/components/docs-page.blade.php
+++ b/resources/views/components/docs-page.blade.php
@@ -16,7 +16,7 @@
 
                 @if($description)
                     <div class="md:blast-w-10/12 blast-mt-4 md:blast-mt-5  blast-wysiwyg">
-                        {!! Str::markdown($description) !!}
+                        {!! \Illuminate\Support\Str::markdown($description) !!}
                     </div>
                 @endif
             </div>

--- a/resources/views/components/ui-docs/full-width.blade.php
+++ b/resources/views/components/ui-docs/full-width.blade.php
@@ -1,7 +1,7 @@
 <div>
     @foreach ($items as $key => $item)
         <div class="{{ $loop->index > 0 ? 'blast-mt-4 blast-pt-4 blast-border-t' : '' }} blast-border-solid blast-border-gray-200">
-            <div class="blast-bg-gray-200 {{ isset($property) && Str::contains($property, 'height') && Str::endsWith($item, '%') ?'blast-h-72' : '' }}">
+            <div class="blast-bg-gray-200 {{ isset($property) && \Illuminate\Support\Str::contains($property, 'height') && \Illuminate\Support\Str::endsWith($item, '%') ?'blast-h-72' : '' }}">
                 <div
                     class="blast-w-full blast-h-10 blast-bg-blue-500"
                     style="{{ $property ?? 'width' }}: {{ $item }};">

--- a/resources/views/components/ui-docs/transition.blade.php
+++ b/resources/views/components/ui-docs/transition.blade.php
@@ -6,7 +6,7 @@
                 blast-font-mono
                 blast-break-words
             ">
-                duration-{{ Str::remove(['ms', 's'], $duration) }}: {{ $duration }};
+                duration-{{ \Illuminate\Support\Str::remove(['ms', 's'], $duration) }}: {{ $duration }};
             </div>
         @endisset
 
@@ -17,7 +17,7 @@
                 blast-font-mono
                 blast-break-words
             ">
-                delay-{{ Str::remove(['ms', 's'], $delay) }}: {{ $delay }};
+                delay-{{ \Illuminate\Support\Str::remove(['ms', 's'], $delay) }}: {{ $delay }};
             </div>
         @endisset
     </div>


### PR DESCRIPTION
Root namespace Facade aliases like `\Str` may be disabled in a Laravel app (e.g. for consistency reasons)