### PR TITLE
add colour and name output to what is running concurrently

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "scripts": {
         "build-tailwind": "npx tailwindcss -i ./resources/frontend/css/main.css -o ./public/main.css --minify",
         "build-storybook": "build-storybook",
-        "storybook": "concurrently -c \"red,blue,yellow\" -n start-storybook,watch-components,watch-data \"start-storybook --quiet -s $STORYBOOK_STATIC_PATH -p 6006\" \"npm run watch-components\" \"npm run watch-data\"",
+        "storybook": "concurrently -c \"red,blue,yellow\" -n start-storybook,watch-components,watch-data \"start-storybook --quiet -s $STORYBOOK_STATIC_PATH -p $STORYBOOK_PORT\" \"npm run watch-components\" \"npm run watch-data\"",
         "watch-components": "chokidar \"$COMPONENTPATH/**/*.blade.php\" -d 0 -c \"cd $PROJECTPATH && php artisan blast:generate-stories --watchEvent={event} -- '{path}';\"",
         "watch-data": "chokidar \"$COMPONENTPATH/data/**/*.php\" \"$COMPONENTPATH/**/*.md\" -d 0 -c \"cd $PROJECTPATH && php artisan blast:generate-stories;\"",
         "parse-tailwind": "node ./src/resolveTailwindConfig.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "scripts": {
         "build-tailwind": "npx tailwindcss -i ./resources/frontend/css/main.css -o ./public/main.css --minify",
         "build-storybook": "build-storybook",
-        "storybook": "concurrently \"start-storybook --quiet -s $STORYBOOK_STATIC_PATH -p $STORYBOOK_PORT\" \"npm run watch-components\" \"npm run watch-data\"",
+        "storybook": "concurrently -c \"red,blue,yellow\" -n start-storybook,watch-components,watch-data \"start-storybook --quiet -s $STORYBOOK_STATIC_PATH -p 6006\" \"npm run watch-components\" \"npm run watch-data\"",
         "watch-components": "chokidar \"$COMPONENTPATH/**/*.blade.php\" -d 0 -c \"cd $PROJECTPATH && php artisan blast:generate-stories --watchEvent={event} -- '{path}';\"",
         "watch-data": "chokidar \"$COMPONENTPATH/data/**/*.php\" \"$COMPONENTPATH/**/*.md\" -d 0 -c \"cd $PROJECTPATH && php artisan blast:generate-stories;\"",
         "parse-tailwind": "node ./src/resolveTailwindConfig.js",


### PR DESCRIPTION
makes it easier to se what is doing what :)

closes #84 

```shell
prefixColors: a list of colors as supported by [chalk](https://www.npmjs.com/package/chalk) or auto for an automatically picked color. If concurrently would run more commands than there are colors, the last color is repeated, unless if the last color value is auto which means following colors are automatically picked to vary. Prefix colors specified per-command take precedence over this list.

 - Custom names and colored prefixes

     $ concurrently --names "HTTP,WATCH" -c "bgBlue.bold,bgMagenta.bold"
     "http-server" "npm run watch"

 - Auto varying colored prefixes

     $ concurrently -c "auto" "npm run watch" "http-server"

 - Mixing auto and manual colored prefixes

     $ concurrently -c "red,auto" "npm run watch" "http-server" "echo hello"

```

ref:
* https://github.com/open-cli-tools/concurrently