### PR TITLE
Manifest paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,18 @@ Blast will attempt to autoload assets from a `mix-manifest.json` (Laravel Mix) o
 
 Default: `true`
 
+#### `mix_manifest_path`
+
+Allows you to customize the path to the mix-manifest file used to autoload assets.
+
+Default: `public_path('mix-manifest.json')`
+
+#### `vite_manifest_path`
+
+Allows you to customize the path to the vite manifest file used to autoload assets.
+
+Default: `public_path('build/manifest.json')`
+
 #### `assets`
 
 An array of urls to the `css` and `js` used by your components. The `css` and `js` urls are seperated out as the `css` is included in the head and the `js` is included before the closing `body` tag.

--- a/config/blast.php
+++ b/config/blast.php
@@ -94,6 +94,11 @@ return [
     // Blast will attempt to autoload assets from a mix-manifest or vite generated manifest if the assets arrays are empty. This option allows you to disable that functionality
     'autoload_assets' => true,
 
+    // paths to the supported manifest files to autoload assets
+    'mix_manifest_path' => public_path('mix-manifest.json'),
+
+    'vite_manifest_path' => public_path('build/manifest.json'),
+
     'assets' => [
         'css' => [],
         'js' => [],

--- a/src/BlastServiceProvider.php
+++ b/src/BlastServiceProvider.php
@@ -115,8 +115,14 @@ final class BlastServiceProvider extends ServiceProvider
             'js' => [],
         ];
 
-        $mix_manifest_path = public_path('mix-manifest.json');
-        $vite_manifest_path = public_path('build/manifest.json');
+        $mix_manifest_path = config(
+            'blast.mix_manifest_path',
+            public_path('mix-manifest.json'),
+        );
+        $vite_manifest_path = config(
+            'blast.vite_manifest_path',
+            public_path('build/manifest.json'),
+        );
 
         // if the mix manifest exists, automatically load assets
         if (is_file($mix_manifest_path)) {


### PR DESCRIPTION
Add the ability to set custom mix and vite asset paths in the blast config

Addresses #82.