### PR TITLE
Add Custom Addon Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ The route Storybook Server uses to render components. You shouldn't need to chan
 
 Default: `config('app.url') . '/storybook_preview'`
 
+#### `storybook_addons`
+
+An array of custom [storybook addons](https://storybook.js.org/integrations/) you'd like to use in your project. Note that not all addons are compatible with Storybook Server. Read about how to configure addons in your stories in the Storybook Configuration section below.
+
+Default: `[]`
+
 #### `auto_documentation`
 
 Blast can automatically generate documentation pages in the form of stories based on your Tailwind config. Use this array to specify which documentation pages to generate. All options are loaded by default.
@@ -337,7 +343,12 @@ There are certain Storybook elements you can configure from within your story bl
     ],
     'actions' => [
         'handles' => ['mouseover', 'click']
-    ]
+    ],
+    'addons' => [
+        'jira' => [
+            'id' => 'ABC-123'
+        ]
+    ],
 ])
 ```
 
@@ -352,6 +363,7 @@ The supported options for this directive are:
 -   `args` - an array of static data used to create storybook fields. You can read more about that [here](https://github.com/storybookjs/storybook/tree/main/app/server#server-rendering). The keys in the array are passed to the blade view and updated when the fields are updated in storybook.
 -   `argTypes` - an array to define the args used for the controls. You can read more about them [here](https://storybook.js.org/docs/react/api/argtypes)
 -   `actions.handles` - an array defining the events that are passed to the `@storybook-actions` addon. You can read more about actions [here](https://storybook.js.org/docs/react/essentials/actions) - See the Action Event Handlers heading.
+-   `addons` - an array to define options for any custom addons. Any options defined here are added to the parameters array in the story. Some addons require you to modify storybook config files which can be done by publishing them to your project directory.
 
 ## Customizing the story view
 

--- a/config/blast.php
+++ b/config/blast.php
@@ -8,6 +8,8 @@ return [
     'storybook_server_url' =>
         env('STORYBOOK_SERVER_HOST', env('APP_URL')) . '/storybook_preview',
 
+    'storybook_addons' => [],
+
     /**
      * Specify which documentation pages to generate for the Tailwind classes used in your application
      * Defaults to `[]` which will render all

--- a/src/Commands/GenerateStories.php
+++ b/src/Commands/GenerateStories.php
@@ -441,6 +441,12 @@ class GenerateStories extends Command
                     ];
                 }
             }
+
+            if (Arr::has($options, 'addons')) {
+                foreach ($options['addons'] as $key => $addon) {
+                    $data['parameters'][$key] = $addon;
+                }
+            }
         }
 
         $data['hash'] = $this->getBladeChecksum(


### PR DESCRIPTION
Adds the ability to install custom [Storybook addons](https://storybook.js.org/integrations/) and configure them within your stories.

Note this is very much a work in progress and not all addons may be supported but we will improve support as we discover issues.