### PR TITLE
Support TypeScript and preprocessor file extensions in asset autoloading

### DIFF
--- a/src/BlastServiceProvider.php
+++ b/src/BlastServiceProvider.php
@@ -132,9 +132,9 @@ final class BlastServiceProvider extends ServiceProvider
 
             if (filled($mix_manifest)) {
                 foreach ($mix_manifest as $key => $asset) {
-                    if (Str::endsWith($key, '.js')) {
+                    if (Str::endsWith($src, ['.js', '.ts', '.jsx', '.tsx'])) {
                         $assets['js'][] = asset($asset);
-                    } elseif (Str::endsWith($key, '.css')) {
+                    } elseif (Str::endsWith($src, ['.css', '.scss', '.sass', '.less'])) {
                         $assets['css'][] = asset($asset);
                     }
                 }
@@ -151,9 +151,9 @@ final class BlastServiceProvider extends ServiceProvider
                     $src = $asset->src ?? '';
                     $file = $asset->file ?? '';
 
-                    if (Str::endsWith($src, '.js')) {
+                    if (Str::endsWith($src, ['.js', '.ts', '.jsx', '.tsx'])) {
                         $assets['js'][] = asset('build/' . $file);
-                    } elseif (Str::endsWith($src, '.css')) {
+                    } elseif (Str::endsWith($src, ['.css', '.scss', '.sass', '.less'])) {
                         $assets['css'][] = asset('build/' . $file);
                     }
                 }

--- a/src/BlastServiceProvider.php
+++ b/src/BlastServiceProvider.php
@@ -132,9 +132,9 @@ final class BlastServiceProvider extends ServiceProvider
 
             if (filled($mix_manifest)) {
                 foreach ($mix_manifest as $key => $asset) {
-                    if (Str::endsWith($src, ['.js', '.ts', '.jsx', '.tsx'])) {
+                    if (Str::endsWith($key, ['.js', '.ts', '.jsx', '.tsx'])) {
                         $assets['js'][] = asset($asset);
-                    } elseif (Str::endsWith($src, ['.css', '.scss', '.sass', '.less'])) {
+                    } elseif (Str::endsWith($key, ['.css', '.scss', '.sass', '.less'])) {
                         $assets['css'][] = asset($asset);
                     }
                 }


### PR DESCRIPTION
## Problem

The current asset autoloading implementation only supports `.js` and `.css` file extensions when reading from the Vite manifest. This causes issues when using:
- TypeScript files (`.ts`, `.tsx`)
- CSS preprocessors (`.scss`, `.sass`, `.less`)

For example, when `vite.config.js` has an entry like:
```js
input: ['resources/js/app.ts']
```

The manifest.json contains:
```json
"resources/js/app.ts": {
  "file": "assets/app-CbgoKSgw.js",
  "src": "resources/js/app.ts"
}
```

But the current code checks `Str::endsWith($src, '.js')` which returns false for `.ts` files, so these assets are not loaded.

## Solution

Updated the `BlastServiceProvider` to support additional file extensions:
- JavaScript/TypeScript: `.js`, `.ts`, `.jsx`, `.tsx`
- CSS/Preprocessors: `.css`, `.scss`, `.sass`, `.less`

## Testing

Tested with a Laravel project using:
- TypeScript files in `vite.config.js` input
- SCSS files in `vite.config.js` input
- `php artisan blast:publish` successfully loads all assets

## Backward Compatibility

This change is backward compatible as it only adds support for additional extensions without changing existing behavior.